### PR TITLE
Ran into a problem with the 0.4.1 release when I pulled it down

### DIFF
--- a/lib/site-object/version.rb
+++ b/lib/site-object/version.rb
@@ -1,3 +1,3 @@
 module SiteObject
-  VERSION = '0.4.1'
+  VERSION = '0.4.2'
 end

--- a/site-object.gemspec
+++ b/site-object.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
     "lib/site-object/site.rb",
     "lib/site-object/version.rb"
   ]
-  s.add_runtime_dependency "activesupport", '>=3.2.10' 
+  s.required_ruby_version = '>= 1.9.3'
+  s.add_runtime_dependency "activesupport", '>= 4.0.0'
   s.add_runtime_dependency "addressable", '~> 2.3', '>= 2.3.8'
 end


### PR DESCRIPTION
at work. I was having problems with an older version of activesupport
and cattr_accessor. Enforcing activesupport >= 4.0.0 and ruby >= 1.9.3,
which should work better.
