### PR TITLE
Fixing a page identification issue

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,8 @@
 machine:
   ruby:
-    version: 2.2.3
+    version: 2.1.9
 test:
-  post:
+  pre:
     - rake install
+  post:
     - bundle exec rspec spec/ruby_lang_tests.rb -f html -o $CIRCLE_ARTIFACTS/test_report.html

--- a/lib/site-object/site.rb
+++ b/lib/site-object/site.rb
@@ -221,7 +221,11 @@ module SiteObject
     end
 
     if found_page && !found_page.required_arguments.empty?
-      return found_page.new(self, found_page.url_template.extract(url))
+      if hsh = found_page.url_template.extract(url)
+        return found_page.new(self, found_page.url_template.extract(url))
+      else
+        return found_page.new(self, found_page.url_template.extract(url.split(/(\?|#)/)[0]))
+      end
     elsif found_page
       return found_page.new(self)
     else

--- a/lib/site-object/version.rb
+++ b/lib/site-object/version.rb
@@ -1,3 +1,3 @@
 module SiteObject
-  VERSION = '0.4.6'
+  VERSION = '0.4.7'
 end


### PR DESCRIPTION
Site#page wasn't able to identify pages in cases where there were mandatory arguments and no arguments were provided (but only when the URL included a query.) There was one place where some handling occurred and it needed to be in a second spot further down as well.
